### PR TITLE
Fix: prevents crash with some TypeScript React syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Change Log
 
-All notable changes to the "remove-unused-imports" extension will be documented in this file.
+## [1.0.5] - 2022-02-09
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+### Fixed
+
+- Crash with some TypeScript React syntax.
 
 ## [1.0.0]
 

--- a/__tests__/__snapshots__/transform.spec.js.snap
+++ b/__tests__/__snapshots__/transform.spec.js.snap
@@ -14,3 +14,47 @@ exports[`removes unused import specifiers and import declarations 1`] = `
   group.property;
   "
 `;
+
+exports[`removes unused imports in TypeScript React without crashing 1`] = `
+"
+  import { useQuery } from \\"@apollo/client\\";
+  import type { NextPage } from \\"next\\";
+  import { useTranslation } from \\"react-i18next\\";
+  import { NoDataFound } from \\"@/NoDataFound\\";
+
+  import { Query, QueryFindFirstUserArgs } from \\"~/@types/generated/graphqlTypes\\";
+  import { whereIdIs } from \\"~/front/gql/helpers/graphql.helpers\\";
+  import { ONE_USER_QUERY } from \\"~/front/gql/queries\\";
+  import { useSession } from \\"~/front/hooks\\";
+
+  const colProps = {
+    md: { span: 12 },
+    span: 24,
+    xl: { span: 6 },
+  };
+
+  const VideosPage: NextPage = () => {
+    const { user } = useSession();
+    const { t } = useTranslation();
+  
+    const { data } = useQuery<Query, QueryFindFirstUserArgs>(
+      ONE_USER_QUERY,
+      whereIdIs(user?.id),
+    );
+  
+  
+    const userData = data?.findFirstUser;
+    if (!userData) {
+      return <NoDataFound dataName={String(t(\\"pages.videos.no-datas\\"))} />;
+    }
+  
+    return (
+      <>
+       
+      </>
+    );
+  };
+
+  export default VideosPage;
+  "
+`;

--- a/__tests__/transform.spec.js
+++ b/__tests__/transform.spec.js
@@ -69,4 +69,5 @@ it('removes unused imports in TypeScript React without crashing', () => {
   `;
 
   expect(() => transform(code)).not.toThrow();
+  expect(transform(code)).toMatchSnapshot();
 });

--- a/__tests__/transform.spec.js
+++ b/__tests__/transform.spec.js
@@ -18,3 +18,55 @@ it('removes unused import specifiers and import declarations', () => {
   const result = transform(code);
   expect(result).toMatchSnapshot();
 });
+
+it('removes unused imports in TypeScript React without crashing', () => {
+  const code = `
+  import { PlusCircleOutlined } from "@ant-design/icons";
+  import { useQuery } from "@apollo/client";
+  import { Card } from "antd";
+  import type { NextPage } from "next";
+  import { useTranslation } from "react-i18next";
+  import { NoDataFound } from "@/NoDataFound";
+  
+  import { Title } from "@/_layout/Title";
+  import { ButtonLink } from "@/ButtonLink";
+  import { LoadingOrError } from "@/LoadingOrError";
+  import { VideoCard } from "@/VideoCard";
+  import { Query, QueryFindFirstUserArgs } from "~/@types/generated/graphqlTypes";
+  import { whereIdIs } from "~/front/gql/helpers/graphql.helpers";
+  import { ONE_USER_QUERY } from "~/front/gql/queries";
+  import { useSession } from "~/front/hooks";
+  
+  const colProps = {
+    md: { span: 12 },
+    span: 24,
+    xl: { span: 6 },
+  };
+  
+  const VideosPage: NextPage = () => {
+    const { user } = useSession();
+    const { t } = useTranslation();
+  
+    const { data } = useQuery<Query, QueryFindFirstUserArgs>(
+      ONE_USER_QUERY,
+      whereIdIs(user?.id),
+    );
+  
+  
+    const userData = data?.findFirstUser;
+    if (!userData) {
+      return <NoDataFound dataName={String(t("pages.videos.no-datas"))} />;
+    }
+  
+    return (
+      <>
+       
+      </>
+    );
+  };
+  
+  export default VideosPage;
+  `;
+
+  expect(() => transform(code)).not.toThrow();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -258,6 +258,23 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz",
+      "integrity": "sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
@@ -322,12 +339,20 @@
       }
     },
     "@babel/plugin-syntax-typescript": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz",
-      "integrity": "sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.7.tgz",
+      "integrity": "sha512-YhUIJHHGkqPgEcMYkPCKTyGUdoGKWtopIycQyjJH8OjvRgOYsXsaKehLVPScKJWAULPxMa4N1vCe6szREFlZ7A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
+          "dev": true
+        }
       }
     },
     "@babel/template": {
@@ -1262,12 +1287,6 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
-    "acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true
-    },
     "acorn-globals": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
@@ -1276,6 +1295,14 @@
       "requires": {
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        }
       }
     },
     "acorn-jsx": {
@@ -1651,9 +1678,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001249",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
-      "integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+      "version": "1.0.30001310",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001310.tgz",
+      "integrity": "sha512-cb9xTV8k9HTIUA3GnPUJCk0meUnrHL5gy5QePfDjxHyNBcnzPzrHFv5GqfP7ue5b1ZyzZL0RJboD6hQlPXjhjg==",
       "dev": true
     },
     "chalk": {
@@ -2656,6 +2683,12 @@
         "eslint-visitor-keys": "^1.3.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        },
         "eslint-visitor-keys": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,5 @@
   "lint-staged": {
     "src/*.ts": "eslint --cache --fix",
     "*": "prettier --ignore-unknown --write"
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",
+    "@babel/plugin-syntax-jsx": "^7.16.7",
+    "@babel/plugin-syntax-typescript": "^7.16.7",
     "@babel/types": "^7.15.0",
     "@types/babel__core": "^7.1.15",
     "@types/glob": "^7.1.3",
@@ -89,5 +91,6 @@
   "lint-staged": {
     "src/*.ts": "eslint --cache --fix",
     "*": "prettier --ignore-unknown --write"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
Recast Babel parser has been replaced by `parseSync` with the required plugins to parse React and TSX files.

Fixes #1 