### PR TITLE
feat: allow to configure imports to preserve

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ The command can be executed every time a file is saved via Code Actions. To enab
 }
 ```
 
+### Preserve specified import identifiers
+
+The extension also supports preserving specified import identifiers, even if they are not used. To enable it, set `removeUnusedImports.preserve` to an array of import identifiers in your VSCode settings:
+
+```json
+"removeUnusedImports.preserve": ["React", "ReactDOM"]
+```
+
 ### Keybinding
 
 This extension **does not provide any keybinding** for the command. You can assign your own custom keybinding for it by pressing the cog icon that appears to the right of the command name in the Command Palette.

--- a/__tests__/__snapshots__/transform.spec.js.snap
+++ b/__tests__/__snapshots__/transform.spec.js.snap
@@ -18,6 +18,19 @@ exports[`does not remove parameter decorators 1`] = `
   "
 `;
 
+exports[`preserves specified import identifiers 1`] = `
+"
+  import { React, useState } from 'react';
+  import { SomeComponent } from './some-path';
+
+  const App = () => {
+    const [count, setCount] = useState(0);
+
+    return <SomeComponent count={count} />;
+  };
+  "
+`;
+
 exports[`removes unused import specifiers and import declarations 1`] = `
 "
   import 'side-effects';

--- a/__tests__/transform.spec.js
+++ b/__tests__/transform.spec.js
@@ -122,3 +122,19 @@ it('supports "satisfies" TS keyword', () => {
 
   expect(() => transform(code)).not.toThrow();
 });
+
+it('preserves specified import identifiers', () => {
+  const code = `
+  import { React, useState } from 'react';
+  import { SomeComponent } from './some-path';
+
+  const App = () => {
+    const [count, setCount] = useState(0);
+
+    return <SomeComponent count={count} />;
+  };
+  `;
+
+  expect(() => transform(code, ['React'])).not.toThrow();
+  expect(transform(code, ['React'])).toMatchSnapshot();
+});

--- a/package.json
+++ b/package.json
@@ -32,10 +32,19 @@
         "command": "remove-unused-imports.main",
         "title": "Remove Unused Imports"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Remove Unused Imports",
+      "properties": {
+        "removeUnusedImports.preserve": {
+          "type": "array",
+          "default": [],
+          "description": "List of import identifiers to preserve. Example: ['React', 'ReactDOM']"
+        }
+      }
+    }
   },
   "activationEvents": [
-    "onCommand:remove-unused-imports.main",
     "onLanguage:javascript",
     "onLanguage:javascriptreact",
     "onLanguage:typescript",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,20 +3,22 @@ import { maxRange } from './constants';
 import { transform } from './transform';
 import { isValidDocumentLanguage } from './utils';
 
-export function removeUnusedImports() {
-  const { activeTextEditor: editor } = window;
+export function removeUnusedImports(preserve?: string[]) {
+  return function () {
+    const { activeTextEditor: editor } = window;
 
-  if (!editor || !editor.document) {
-    return;
-  }
+    if (!editor || !editor.document) {
+      return;
+    }
 
-  if (!isValidDocumentLanguage(editor.document)) {
-    return;
-  }
+    if (!isValidDocumentLanguage(editor.document)) {
+      return;
+    }
 
-  const result = transform(editor.document.getText());
+    const result = transform(editor.document.getText(), preserve);
 
-  if (result) {
-    return editor.edit((edit) => edit.replace(maxRange, result));
-  }
+    if (result) {
+      return editor.edit((edit) => edit.replace(maxRange, result));
+    }
+  };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,19 @@
-import { commands, ExtensionContext, languages } from 'vscode';
+import { commands, ExtensionContext, languages, workspace } from 'vscode';
 import CodeActionsProvider from './CodeActionsProvider';
 import { removeUnusedImports } from './commands';
 
 export function activate(context: ExtensionContext) {
   const codeActionsProvider = new CodeActionsProvider();
 
+  const preserve = workspace
+    .getConfiguration('removeUnusedImports')
+    .get<string[]>('preserve');
+
   context.subscriptions.push(
-    commands.registerCommand('remove-unused-imports.main', removeUnusedImports),
+    commands.registerCommand(
+      'remove-unused-imports.main',
+      removeUnusedImports(preserve),
+    ),
 
     languages.registerCodeActionsProvider(
       { scheme: 'file', pattern: '**/*.{js,jsx,ts,tsx}' },

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -31,7 +31,7 @@ function collectParameterDecorators(path: NodePath<types.TSParameterProperty>) {
   });
 }
 
-export function removeUnusedImports(): PluginObj {
+export function removeUnusedImports(preserve?: string[]): PluginObj {
   return {
     visitor: {
       Program(path: NodePath<types.Program>) {
@@ -44,6 +44,8 @@ export function removeUnusedImports(): PluginObj {
       ImportDeclaration(path: NodePath<types.ImportDeclaration>) {
         path.get('specifiers').forEach((specifier) => {
           if (decorators.has(specifier.node.local.name)) return;
+          if (preserve?.includes(specifier.node.local.name)) return;
+
           isUnusedImportSpecifier(specifier) && specifier.remove();
           hasAllSpecifiersRemoved(path) && path.remove();
         });

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -2,7 +2,7 @@ import { parse, print } from 'recast';
 import { transformFromAstSync, parseSync, TransformOptions } from '@babel/core';
 import { removeUnusedImports } from './plugin';
 
-export function transform(code: string) {
+export function transform(code: string, preserve?: string[]) {
   const ast = parse(code, {
     parser: {
       parse(code: string) {
@@ -21,7 +21,7 @@ export function transform(code: string) {
     cloneInputAst: false,
     code: false,
     ast: true,
-    plugins: [removeUnusedImports],
+    plugins: [removeUnusedImports(preserve)],
   } as TransformOptions)!;
 
   return babelAst && print(babelAst).code;


### PR DESCRIPTION
Added a new setting to specify a list of import identifiers to preserve, even if unused.

Closes #19 